### PR TITLE
Parse units' droppable items

### DIFF
--- a/lib/translators/UnitsTranslator.js
+++ b/lib/translators/UnitsTranslator.js
@@ -126,13 +126,15 @@ const UnitsTranslator = {
             unit.hitpoints = b.readInt(); // -1 = use default
             unit.mana = b.readInt(); // -1 = use default, 0 = unit doesn't have mana
 
+            unit.droppable = [];
             let droppedItemSetPtr = b.readInt(),
                 numDroppedItemSets = b.readInt();
             for(let j = 0; j < numDroppedItemSets; j++) {
                 let numDroppableItems = b.readInt();
                 for(let k = 0; k < numDroppableItems; k++) {
-                    b.readChars(4); // Item ID
-                    b.readInt(); // % chance to drop
+                    itemID = b.readChars(4); // Item ID
+                    itemChance = b.readInt(); // % chance to drop
+                    unit.droppable.push([itemID, itemChance]);
                 }
             }
 
@@ -199,7 +201,6 @@ const UnitsTranslator = {
 
             result.push(unit);
         }
-
         return {
             errors: [],
             json: result


### PR DESCRIPTION
This was disabled in the original repo, but it works for all 128 Blizzard/community TFT melee maps.